### PR TITLE
[changed] do nothing when received sigterm(15)

### DIFF
--- a/libbeat/service/service.go
+++ b/libbeat/service/service.go
@@ -50,8 +50,11 @@ func HandleSignals(stopFunction func(), cancel context.CancelFunc) {
 		sig := <-sigc
 
 		switch sig {
-		case syscall.SIGINT, syscall.SIGTERM:
-			logger.Debug("Received sigterm/sigint, stopping")
+		case syscall.SIGTERM:
+			logger.Debug("Received sigterm, do nothing")
+			return
+		case syscall.SIGINT:
+			logger.Debug("Received sigint, stopping")
 		case syscall.SIGHUP:
 			logger.Debug("Received sighup, stopping")
 		}

--- a/libbeat/service/service.go
+++ b/libbeat/service/service.go
@@ -45,14 +45,15 @@ func HandleSignals(stopFunction func(), cancel context.CancelFunc) {
 
 	// On termination signals, gracefully stop the Beat
 	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+
+	// Ignore SIGTERM and do not notify SIGTERM
+	signal.Notify(sigc, syscall.SIGINT, syscall.SIGHUP)
+	signal.Ignore(syscall.SIGTERM)
+
 	go func() {
 		sig := <-sigc
 
 		switch sig {
-		case syscall.SIGTERM:
-			logger.Debug("Received sigterm, do nothing")
-			return
 		case syscall.SIGINT:
 			logger.Debug("Received sigint, stopping")
 		case syscall.SIGHUP:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR forked from v7.10.1 and branched it as master-v7.10.1！
This PR did one thing: **Ignore signal SIGTERM(15)**!
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
We deploy *filebeat* as a sidecar and we want to control the order of stop, so we don't want the container to receive the signal SIGTERM.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
